### PR TITLE
Fix usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install diy-handlebars-helpers
 ### Basic Use
 ```javascript
 var helpers = require('diy-handlebars-helpers');
-helpers(); // returns a dictionary of helpers { name: function () {} }
+// returns a dictionary of helpers { name: function () {} }
 ```
 
 Registering helpers w/ handlebars


### PR DESCRIPTION
The README was suggesting that the module exports a function, but in reality it exports a raw object:

``` js
> require('diy-handlebars-helpers')()
TypeError: require(...) is not a function
    at repl:1:34
    at REPLServer.defaultEval (repl.js:252:27)
    at bound (domain.js:287:14)
    at REPLServer.runBound [as eval] (domain.js:300:12)
    at REPLServer.<anonymous> (repl.js:417:12)
    at emitOne (events.js:82:20)
    at REPLServer.emit (events.js:169:7)
    at REPLServer.Interface._onLine (readline.js:210:10)
    at REPLServer.Interface._line (readline.js:549:8)
    at REPLServer.Interface._ttyWrite (readline.js:826:14)
```

vs 

``` js
> require('diy-handlebars-helpers')
{ 'abbr-count': [Function: abbrCount],
  calendar: [Function: calendar],
  capitalize: [Function: capitalize],
  ...
```
